### PR TITLE
Implemented configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Quick Instructions
 
 Options:
 * `--console`, `-c`: Output to stdout in a readable format (default)
+* `--config`, `-f`: Path to configuration file to use
 * `--json`, `-j`: Output to stdout as json
 * `--providers`, `-p`: Output to stdout a list of available providers
 * `--provider-dir`, `-pd`: Define a different providers directory
@@ -21,6 +22,22 @@ Options:
 This starts a WSGI-compliant web server at the specified port (default `8181`).  The
 api is invoked with `http://domain:port/provider/query`, or `http://domain:port/providers`
 (for a list of available providers).
+
+Configuration file structure
+----------------------------
+
+It is possible to use an optional configuration file by using the
+`--config`/`- f` flag or placing a file called `mdgt.conf` in the current working
+directory. It can have the following values:
+
+```conf
+console = true|false
+json = true|false
+provider-dir = path/to/dir
+```
+
+Note that command-line arguments will override those present in the configuration
+file.
 
 Development instructions
 ------------------------

--- a/mdgt/__main__.py
+++ b/mdgt/__main__.py
@@ -1,4 +1,8 @@
 import argparse
+import configparser
+import sys
+from io import StringIO
+from pathlib import Path
 from .mdgt import consolePrint, jsonPrint, listProvs
 from .provider import Provider
 from .webserve import serve as webserve
@@ -20,6 +24,8 @@ parser.add_argument('-p', '--providers', action='store_true',
 outputGroup = parser.add_mutually_exclusive_group()
 outputGroup.add_argument('-c', '--console', action='store_true',
                          help="Output console-formatted text (default).")
+outputGroup.add_argument('-f', '--config', nargs='?', const=None,
+                         help="Path to configuration file to use.")
 outputGroup.add_argument('-j', '--json', action='store_true',
                          help="Output json.")
 outputGroup.add_argument('-pd', '--provider-dir', nargs='?', const=None,
@@ -29,6 +35,31 @@ outputGroup.add_argument('-w', '--webserver', nargs='?', const=8181,
                          specified port (default 8181).")
 args = parser.parse_args()
 
+# Config file
+if args.config:
+    conf_file = Path(args.config)
+
+    if not conf_file.exists():
+        sys.exit("Configuration file not found")
+
+else:
+    conf_file = Path('./mdgt.conf')
+
+if conf_file.exists():
+    # Override args
+    conf_parser = configparser.ConfigParser()
+
+    # Add dummy section for reading
+    conf_parser.read_string(
+        StringIO("[mdgt]\n%s" % conf_file.open().read()).read()
+    )
+
+    section = conf_parser['mdgt']
+
+    args.console = args.console or section.getboolean('console', True)
+    args.json = args.json or section.getboolean('json', False)
+    args.provider_dir = args.provider_dir or section.get('provider-dir')
+
 if args.providers:
     listProvs()
 elif args.webserver:
@@ -37,7 +68,7 @@ elif args.webserver:
 elif (not args.provider) and (not args.query):
     print("Provider and query required. See --help")
 elif args.json:
-    prov = Provider(args.provider, args._provider_dir)
+    prov = Provider(args.provider, args.provider_dir)
     jsonPrint(prov.scrape(args.query))
 else:
     prov = Provider(args.provider, args.provider_dir)


### PR DESCRIPTION
As stated in #8, this commit adds the possibility of using a configuration file for common command line options. This file can either be passed as an argument with the `--config`/`-f` flag o be placed in the CWD named as `mdgt.conf`. It has the following structure:

``` conf
console = true|false
json = true|false
provider-dir = path/to/providers/dir
```

The `webserver` parameter has not been included, given that it has a default value which would override the one in the config file.
